### PR TITLE
Synchronize calls to the liveness checker 'checkTrace' methods

### DIFF
--- a/tlatools/src/tlc2/tool/liveness/LiveCheck.java
+++ b/tlatools/src/tlc2/tool/liveness/LiveCheck.java
@@ -255,7 +255,7 @@ public class LiveCheck implements ILiveCheck {
 	/* (non-Javadoc)
 	 * @see tlc2.tool.liveness.ILiveCheck#checkTrace(tlc2.tool.StateVec)
 	 */
-	public void checkTrace(final StateVec stateTrace) throws InterruptedException, IOException {
+	public synchronized void checkTrace(final StateVec stateTrace) throws InterruptedException, IOException {
 		// Add the first state to the LiveCheck as the current init state
 		addInitState(stateTrace.elementAt(0), stateTrace.elementAt(0).fingerPrint());
 		

--- a/tlatools/src/tlc2/tool/liveness/LiveCheck1.java
+++ b/tlatools/src/tlc2/tool/liveness/LiveCheck1.java
@@ -484,7 +484,7 @@ public class LiveCheck1 implements ILiveCheck {
 	 * Checks if the behavior graph constructed from a state trace contains any
 	 * "bad" cycle.
 	 */
-	public void checkTrace(final StateVec trace) {
+	public synchronized void checkTrace(final StateVec trace) {
 		stateTrace = trace;
 		for (int soln = 0; soln < solutions.length; soln++) {
 			OrderOfSolution os = solutions[soln];


### PR DESCRIPTION
Additional follow up fix for issue #147.. Addresses issue with simulation workers concurrently accessing a shared liveness checker object.